### PR TITLE
Use interface for balls

### DIFF
--- a/ball.go
+++ b/ball.go
@@ -1,7 +1,5 @@
 package consistent
 
-type Ball []byte
-
-func (b Ball) String() string {
-	return string(b)
+type Ball interface {
+	String() string
 }

--- a/consistent.go
+++ b/consistent.go
@@ -297,7 +297,7 @@ func (c *Consistent) LoadDistribution() map[string]float64 {
 // Locate finds a home for given ball
 func (c *Consistent) Locate(ball Ball) *Bin {
 	c.mu.Lock()
-	partID := c.FindPartitionID(ball)
+	partID := c.FindPartitionID([]byte(ball.String()))
 	c.balls[partID] = ball
 	c.mu.Unlock()
 	return c.GetPartitionOwner(partID)
@@ -313,7 +313,7 @@ func (c *Consistent) MaximumLoad() float64 {
 func (c *Consistent) relocate() {
 	newBalls := map[PartitionID][]Ball{}
 	for _, ball := range c.balls {
-		partID := c.FindPartitionID(ball)
+		partID := c.FindPartitionID([]byte(ball.String()))
 		if len(newBalls[partID]) == 0 {
 			newBalls[partID] = []Ball{ball}
 			continue

--- a/consistent_test.go
+++ b/consistent_test.go
@@ -43,10 +43,16 @@ func (hs hasher) Sum64(data []byte) uint64 {
 	return h.Sum64()
 }
 
+type ball []byte
+
+func (b ball) String() string {
+	return string(b)
+}
+
 func initialBalls(cnt int) []Ball {
 	balls := make([]Ball, cnt)
 	for i := 0; i < cnt; i++ {
-		balls[i] = Ball([]byte(fmt.Sprintf("%s%d", ballPrefix, i)))
+		balls[i] = ball([]byte(fmt.Sprintf("%s%d", ballPrefix, i)))
 	}
 	return balls
 }
@@ -220,7 +226,7 @@ func TestConsistent_Delete(t *testing.T) {
 			expected: 3,
 		},
 		"fail on non existing ball": {
-			ball: Ball([]byte("not exist")),
+			ball: ball([]byte("not exist")),
 			want: ErrBallNotFound,
 		},
 	}


### PR DESCRIPTION
## WHY

For flexibility.
The ball can be any type unless it implements the `Ball` interface.
