### PR TITLE
Add missing go comments to public fields, structs, etc

### DIFF
--- a/ball.go
+++ b/ball.go
@@ -1,5 +1,9 @@
 package consistent
 
+// Ball represents data to be placed on the ring.
+// In most cases, it is a subsequent server for load balancing, data for sharding, etc but
+// it can be anything unless it implements this interface.
 type Ball interface {
+	// String returns the name of the ball.
 	String() string
 }

--- a/bin.go
+++ b/bin.go
@@ -1,16 +1,22 @@
 package consistent
 
+// Bin represents an entity that serves the balls.
+// Usually it's a server but it can be anything.
 type Bin struct {
 	Name         string
 	PartitionIDs []PartitionID
 }
 
+// NewBin generates a bin from the passed name.
+// In most cases, it's IP address of the server, hash of the metadata, etc.
+// It can be anything, it's up to you.
 func NewBin(name string) Bin {
 	return Bin{
 		Name: name,
 	}
 }
 
+// String returns the bin's name.
 func (b Bin) String() string {
 	return b.Name
 }

--- a/consistent.go
+++ b/consistent.go
@@ -1,3 +1,6 @@
+/*
+
+*/
 package consistent
 
 import (


### PR DESCRIPTION
## WHY

To be developer friendly.